### PR TITLE
Add 'html5mode' option, some customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ngdocs: {
   options: {
     dest: 'docs'
     scripts: ['../app.min.js'],
+    html5Mode: true,
     analytics: {
           account: 'UA-08150815-0',
           domainName: 'my-domain.com'
@@ -66,6 +67,10 @@ Optional include Google Analytics in the documentation app.
 
 ####discussions
 Optional include [discussions](http://http://disqus.com) in the documentation app.
+
+####html5Mode
+[default] 'true'
+Whether or not to enable `html5Mode` in the docs application.  If true, then links will be absolute.  If false, they will be prefixed by `#/`.  
 
 ###Targets
 Each grunt target creates a section in the documentation app.

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   },
   "peerDependencies": {
     "grunt": "0.4.x"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-watch": "~0.4.3"
   }
 }

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -23,7 +23,7 @@ var BOOLEAN_ATTR = {};
 });
 
 //////////////////////////////////////////////////////////
-function Doc(text, file, line) {
+function Doc(text, file, line, options) {
   if (typeof text == 'object') {
     for ( var key in text) {
       this[key] = text[key];
@@ -33,6 +33,7 @@ function Doc(text, file, line) {
     this.file = file;
     this.line = line;
   }
+  this.options = options || {};
   this.scenarios = this.scenarios || [];
   this.requires = this.requires || [];
   this.param = this.param || [];
@@ -93,9 +94,10 @@ Doc.prototype = {
    * @returns {string} Absolute url
    */
   convertUrlToAbsolute: function(url) {
+    var prefix = this.options.html5Mode ? '' : '#/';
     if (url.substr(-1) == '/') return url + 'index';
     if (url.match(/\//)) return url;
-    return this.section + '/' + url;
+    return prefix + this.section + '/' + url;
   },
 
   markdown: function(text) {

--- a/src/reader.js
+++ b/src/reader.js
@@ -8,14 +8,14 @@ exports.process = process;
 var ngdoc = require('./ngdoc.js'),
     NEW_LINE = /\n\r?/;
 
-function process(content, file, section) {
+function process(content, file, section, options) {
   if (/\.js$/.test(file)) {
     processJsFile(content, file).forEach(function(doc) {
       exports.docs.push(doc);
     });
   } else if (file.match(/\.ngdoc$/)) {
     var header = '@section ' + section + '\n';
-    exports.docs.push(new ngdoc.Doc(header + content.toString(),file, 1).parse());
+    exports.docs.push(new ngdoc.Doc(header + content.toString(),file, 1, options).parse());
   }
 }
 

--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -79,18 +79,21 @@
       <div class="navbar-inner">
         <div class="container">
           <ul class="nav">
-            <li ng-repeat="(url, name) in sections"><a href="{{url}}"><i class="icon-book icon-white"></i> {{name}}</a></li>
+            <li ng-repeat="(url, name) in sections"><a ng-href="{{url}}"><i class="icon-book icon-white"></i> {{name}}</a></li>
+            <!--
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <i class="icon-bookmark icon-white"></i> AngularJS <b class="caret"></b>
-              </a>
+e             </a>
               <ul class="dropdown-menu">
                 <li class="disabled"><a href="http://angularjs.org/">Why AngularJS?</a></li>
                  <li><a href="http://docs.angularjs.org/tutorial">Tutorial</a></li>
                 <li><a href="http://docs.angularjs.org/api/">API Reference</a></li>
                 <li><a href="http://docs.angularjs.org/guide/">Developer Guide</a></li>
               </ul>
+              
             </li>
+            -->
           </ul>
         </div>
       </div>
@@ -139,32 +142,32 @@
 
           <ul class="nav nav-list" ng-hide="page">
             <li ng-repeat="page in pages" ng-class="navClass(page)" class="api-list-item">
-              <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
+              <a href="#/{{page.url}}" tabindex="2">{{page.shortName}}</a>
             </li>
           </ul>
 
           <ul class="nav nav-list well" ng-repeat="module in modules" class="api-list-item">
             <li class="nav-header module">
-              <a class="guide" href="{{URL.module}}">module</a>
+              <a class="guide">module</a>
               <a class="code" href="{{module.url}}">{{module.name}}</a>
             </li>
 
             <li class="nav-header section" ng-show="module.directives">
-              <a href="{{URL.directive}}" class="guide">directive</a>
+              <a class="guide">directive</a>
             </li>
             <li ng-repeat="page in module.directives" ng-class="navClass(page)" ng-animate="'expand'" class="api-list-item">
               <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
             </li>
 
             <li class="nav-header section" ng-show="module.filters">
-              <a href="{{URL.filter}}" class="guide">filter</a>
+              <a class="guide">filter</a>
             </li>
             <li ng-repeat="page in module.filters" ng-class="navClass(page)" ng-animate="'expand'" class="api-list-item">
               <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
             </li>
 
             <li class="nav-header section" ng-show="module.services">
-              <a href="{{URL.service}}" class="guide">service</a>
+              <a class="guide">service</a>
             </li>
             <li ng-repeat="service in module.services" ng-animate="'expand'" ng-class="navClass(service.instance, service.provider)" class="api-list-item">
               <a ng-show="service.provider" class="pull-right" href="{{service.provider.url}}" tabindex="2"><i class="icon-cog"></i></a>
@@ -172,14 +175,14 @@
             </li>
 
             <li class="nav-header section" ng-show="module.types">
-              <a href="{{URL.type}}" class="guide">Types</a>
+              <a class="guide">Types</a>
             </li>
             <li ng-repeat="page in module.types" ng-class="navClass(page)" ng-animate="'expand'" class="api-list-item">
               <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
             </li>
 
             <li class="nav-header section" ng-show="module.globals">
-              <a href="{{URL.api}}" class="global guide">global APIs</a>
+              <a class="global guide">global APIs</a>
               &nbsp;
             </li>
             <li ng-repeat="page in module.globals" ng-class="navClass(page)" class="api-list-item">

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -261,12 +261,13 @@ docsApp.serviceFactory.sections = function serviceFactory() {
   };
 
   angular.forEach(NG_DOCS.pages, function(page) {
-    page.url = page.section + '/' +  page.id;
+    var url = page.section + '/' +  page.id;
     if (page.id == 'angular.Module') {
       page.partialUrl = 'partials/api/angular.IModule.html';
     } else {
-      page.partialUrl = 'partials/' + page.url + '.html';
+      page.partialUrl = 'partials/' + url + '.html';
     }
+    page.url = (NG_DOCS.html5Mode ? '' : '#/') + url;
     if (!sections[page.section]) { sections[page.section] = []; }
     sections[page.section].push(page);
   });
@@ -322,7 +323,10 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
    Watches
    ***********************************/
 
-  $scope.sections = NG_DOCS.sections;
+  $scope.sections = {};
+  angular.forEach(NG_DOCS.sections, function(section, url) {
+    $scope.sections[(NG_DOCS.html5Mode ? '' : '#/') + url] = section;
+  });
   $scope.$watch(function docsPathWatch() {return $location.path(); }, function docsPathWatchAction(path) {
     var parts = path.split('/'),
       sectionId = parts[1],
@@ -462,7 +466,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
       if (!module) {
         module = cache[name] = {
           name: name,
-          url: 'api/' + name,
+          url: (NG_DOCS.html5Mode ? '' : '#/') + 'api/' + name,
           globals: [],
           directives: [],
           services: [],
@@ -529,7 +533,9 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
 
 angular.module('docsApp', ['bootstrap', 'bootstrapPrettify']).
   config(function($locationProvider) {
-    $locationProvider.html5Mode(true).hashPrefix('!');
+    if (NG_DOCS.html5Mode) {
+      $locationProvider.html5Mode(true).hashPrefix('!');
+    }
   }).
   factory(docsApp.serviceFactory).
   directive(docsApp.directive).


### PR DESCRIPTION
I added an option for html5Mode, which defaults to true.  If false, it will make all the docs links be hash-links.  This enables me to host the docs on gh-pages.

I also removed everything which links back to http://docs.angularjs.org.

Another thing I want to add is an obvious "github" link on the navbar, and share/star buttons (similar to lots of projects, eg http://angular-ui.github.io/bootstrap).

Perhaps just a customizable header/footer as well would be cool.

To try it out, just put 'ajoslin/grunt-ngdocs' as a dependency in package.json.
