### PR TITLE
feat(navTemplate): Preprocess via grunt.template

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ should be that of listitems inside a bootstrap navbar:
 ```
 Example: 'templates/my-nav.html'
 
+The template, if specified, is pre-processed using [grunt.template](https://github.com/gruntjs/grunt/wiki/grunt.template#grunttemplateprocess).
+
 ###Targets
 Each grunt target creates a section in the documentation app.
 

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -102,7 +102,7 @@ module.exports = function(grunt) {
     setup.pages = _.union(setup.pages, ngdoc.metadata(reader.docs));
 
     if (options.navTemplate) {
-      options.navContent = grunt.file.read(options.navTemplate);
+      options.navContent = grunt.template.process(grunt.file.read(options.navTemplate));
     } else {
       options.navContent = '';
     }


### PR DESCRIPTION
angular-ui/bootstrap's nav template includes a reference to the package.json version in a lo-dash template, and I see this as being a fairly common thing to do, whether the version information is coming from bower.json or whatever.

A simple fix for this is to just

``` js
options.navContent = grunt.template.process(grunt.file.read(options.navTemplate));
```

rather than simply

``` js
options.navContent = grunt.file.read(options.navTemplate);
```

I'll send a patch real quick. But this seems like something that would be sort of an expected behaviour
