### PR TITLE
feat(syntax): override module name parsing

### DIFF
--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -257,7 +257,12 @@ Doc.prototype = {
     function flush() {
       if (atName) {
         var text = trim(atText.join('\n')), match;
-        if (atName == 'param') {
+        if (atName == 'module') {
+          match = text.match(/^\s*(\S+)\s*$/);
+          if (match) {
+            self.moduleName = match[1];
+          }
+        } else if (atName == 'param') {
           match = text.match(/^\{([^}]+)\}\s+(([^\s=]+)|\[(\S+)=([^\]]+)\])\s+(.*)/);
                              //  1      1    23       3   4   4 5      5  2   6  6
           if (!match) {
@@ -322,7 +327,7 @@ Doc.prototype = {
     var dom = new DOM(),
       self = this;
 
-    dom.h(title(this.name, this.ngdoc == 'overview'), function() {
+    dom.h(title(this.moduleName, this.name, this.ngdoc == 'overview'), function() {
 
       notice('deprecated', 'Deprecated API', self.deprecated);
       if (self.ngdoc != 'overview') {
@@ -763,7 +768,7 @@ var GLOBALS = /^angular\.([^\.]+)$/,
     MODULE_TYPE = /^([^\.]+)\..+\.([A-Z][^\.]+)$/;
 
 
-function title(text, overview) {
+function title(module, text, overview) {
   if (!text) return text;
   var match,
     module,
@@ -798,7 +803,7 @@ function title(text, overview) {
     name = match[3];
     type = match[2];
   } else if (match = text.match(MODULE_TYPE)) {
-    module = match[1];
+    module = module || match[1];
     name = match[2];
     type = 'type';
   } else if (match = text.match(MODULE_SERVICE)) {
@@ -806,7 +811,7 @@ function title(text, overview) {
       // module name with dots looks like a service
       module = text;
     } else {
-      module = match[1];
+      module = module || match[1];
       name = match[2] + (match[3] || '');
       type = 'service';
     }
@@ -879,7 +884,8 @@ function metadata(docs){
     pages.push({
       section: doc.section,
       id: doc.id,
-      name: title(doc.name),
+      name: title(doc.moduleName, doc.name),
+      moduleName: doc.moduleName,
       shortName: shortName,
       type: doc.ngdoc,
       keywords:doc.keywords()

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -362,8 +362,10 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
       } else if (match = partialId.match(GLOBALS)) {
         breadcrumb.push({ name: partialId });
       } else if (match = partialId.match(MODULE)) {
+        match[1] = page.moduleName || match[1];
         breadcrumb.push({ name: match[1] });
       } else if (match = partialId.match(MODULE_FILTER)) {
+        match[1] = page.moduleName || match[1];
         breadcrumb.push({ name: match[1], url: sectionPath + '/' + match[1] });
         breadcrumb.push({ name: match[2] });
       } else if (match = partialId.match(MODULE_DIRECTIVE)) {
@@ -374,9 +376,11 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
         breadcrumb.push({ name: 'input' });
         breadcrumb.push({ name: match[2] });
       } else if (match = partialId.match(MODULE_CUSTOM)) {
+        match[1] = page.moduleName || match[1];
         breadcrumb.push({ name: match[1], url: sectionPath + '/' + match[1] });
         breadcrumb.push({ name: match[3] });
       } else if (match = partialId.match(MODULE_TYPE)) {
+        match[1] = page.moduleName || match[1];
         breadcrumb.push({ name: match[1], url: sectionPath + '/' + match[1] });
         breadcrumb.push({ name: match[2] });
       }  else if (match = partialId.match(MODULE_SERVICE)) {
@@ -384,6 +388,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
           // module name with dots looks like a service
           breadcrumb.push({ name: partialId });
         } else {
+          match[1] = page.moduleName || match[1];
           breadcrumb.push({ name: match[1], url: sectionPath + '/' + match[1] });
           breadcrumb.push({ name: match[2] + (match[3] || '') });
         }
@@ -455,22 +460,22 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
       } else if (match = id.match(GLOBALS)) {
         module('ng', section).globals.push(page);
       } else if (match = id.match(MODULE)) {
-        module(match[1], section);
+        module(page.moduleName || match[1], section);
       } else if (match = id.match(MODULE_FILTER)) {
-        module(match[1], section).filters.push(page);
+        module(page.moduleName || match[1], section).filters.push(page);
       } else if (match = id.match(MODULE_DIRECTIVE)) {
-        module(match[1], section).directives.push(page);
+        module(page.moduleName || match[1], section).directives.push(page);
       } else if (match = id.match(MODULE_DIRECTIVE_INPUT)) {
-        module(match[1], section).directives.push(page);
+        module(page.moduleName || match[1], section).directives.push(page);
       } else if (match = id.match(MODULE_CUSTOM)) {
-        module(match[1], section).others.push(page);
+        module(page.moduleName || match[1], section).others.push(page);
       } else if (match = id.match(MODULE_TYPE)) {
-        module(match[1], section).types.push(page);
+        module(page.moduleName || match[1], section).types.push(page);
       } else if (match = id.match(MODULE_SERVICE)) {
         if (page.type === 'overview') {
           module(id, section);
         } else {
-          module(match[1], section).service(match[2])[match[3] ? 'provider' : 'instance'] = page;
+          module(page.moduleName || match[1], section).service(match[2])[match[3] ? 'provider' : 'instance'] = page;
         }
       } else if (match = id.match(MODULE_MOCK)) {
         module('ngMock', section).globals.push(page);


### PR DESCRIPTION
Provides syntax to allow the overriding of module names, which is broken in the case of modules containing periods (a common convention).

Example:

``` js
/**
* @ngdoc function
* @name ui.bootstrap.$modal.ModalInstance
*
*  // Add this to avoid using the parsed module name, which is often incorrect
* @module ui.bootstrap
* ...
*/
```

Using the module name parser, the module name would end up being 'ui'.  However, this is not necessarily acceptable for projects like this where the module name contains a domain-name looking pattern to denote the type of module / package and authors, as well as the package name itself and finally sub-package components.

In short, this feature is somewhat necessary, unless changes are made to the syntax to use the directive-style syntax (or similar) for each and every object type.
