### PR TITLE
capture full module path for types

### DIFF
--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -765,7 +765,7 @@ var GLOBALS = /^angular\.([^\.]+)$/,
     MODULE_DIRECTIVE_INPUT = /^(.+)\.directive:input\.([^\.]+)$/,
     MODULE_CUSTOM = /^(.+)\.([^\.]+):([^\.]+)$/,
     MODULE_SERVICE = /^(.+)\.([^\.]+?)(Provider)?$/,
-    MODULE_TYPE = /^([^\.]+)\..+\.([A-Z][^\.]+)$/;
+    MODULE_TYPE = /^([^\.]+\..+)\.([A-Z][^\.]+)$/;
 
 
 function title(module, text, overview) {

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -286,7 +286,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
       MODULE_FILTER = /^(.+)\.filter:([^\.]+)$/,
       MODULE_CUSTOM = /^(.+)\.([^\.]+):([^\.]+)$/,
       MODULE_SERVICE = /^(.+)\.([^\.]+?)(Provider)?$/,
-      MODULE_TYPE = /^([^\.]+)\..+\.([A-Z][^\.]+)$/;
+      MODULE_TYPE = /^([^\.]+\..+)\.([A-Z][^\.]+)$/;
 
 
   /**********************************


### PR DESCRIPTION
If you define something.services.User, User is considered a type
but is listed in module "something" instead of "something.services".

With this patch the full module path is captured.
