### PR TITLE
Fixed issue with requirejs being injected in options.scripts

### DIFF
--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -29,16 +29,20 @@
       addTag('link', {rel: 'stylesheet', href: 'css/prettify.css', type: 'text/css'});
       addTag('link', {rel: 'stylesheet', href: 'css/docs.css', type: 'text/css'});
       addTag('link', {rel: 'stylesheet', href: 'css/animations.css', type: 'text/css'});
+
       <% _.forEach(styles, function(url) { %>
          addTag('link', {rel: 'stylesheet', href: '<%= url %>', type: 'text/css'}, sync);
       <% }); %>
+
+      addTag('script', {src: 'js/google-code-prettify.js'}, sync);
+      addTag('script', {src: 'js/marked.js'}, sync);
+
       <% _.forEach(scripts, function(url) { %>
         addTag('script', {src: '<%= url %>'}, sync);
       <% }); %>
+
       addTag('script', {src: 'js/angular-bootstrap.js'}, sync);
       addTag('script', {src: 'js/angular-bootstrap-prettify.js'}, sync);
-      addTag('script', {src: 'js/google-code-prettify.js'}, sync);
-      addTag('script', {src: 'js/marked.js'}, sync);
       addTag('script', {src: 'js/docs-setup.js'}, sync);
       addTag('script', {src: 'js/docs.js'}, sync);
 


### PR DESCRIPTION
Those 2 scripts (google-code-pretify and marked) try to use require if they find it but use an anonymous define which doesn't work with require well, preventing the docs to work when using require.

I therefore moved google-code-pretify and marked scripts calls above user configurable ones, in case requirejs is part of the configured scripts.

Thanks!
