### PR TITLE
Update docs.css

### DIFF
--- a/src/templates/css/docs.css
+++ b/src/templates/css/docs.css
@@ -15,12 +15,12 @@ img.AngularJS-small {
   line-height: 18px
 }
 
-.header img {
+.navbar img {
   max-height: 40px;
   padding-right: 20px;
 }
 
-.header img+.brand {
+.navbar img+.brand {
   padding: 10px 20px 10px 10px;
 }
 


### PR DESCRIPTION
Hello,

The max-height attribute isn't affecting the IE8, because IE8 is self closing the header element: `<header class="header"/>`. So the img styling not affect the header image anymore.

I chose `.navbar`, because it's the only content in the header element.

Greetings
