### PR TITLE
Allow service names to be capitalized

### DIFF
--- a/spec/ngdocSpec.js
+++ b/spec/ngdocSpec.js
@@ -106,6 +106,13 @@ describe('ngdoc', function() {
         expect(doc.links).toContain('api/angular.link');
       });
 
+      it('should correctly parse capitalized service names', function(){
+        var doc = new Doc('@ngdoc service\n@name my.module.Service');
+        doc.parse();
+        expect(ngdoc.metadata([doc])[0].shortName).toEqual('my.module.Service');
+        expect(ngdoc.metadata([doc])[0].moduleName).toEqual('my.module');
+      });
+
       describe('convertUrlToAbsolute', function() {
         var doc;
 

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -983,7 +983,7 @@ function title(doc) {
     return makeTitle('input [' + match[2] + ']', 'directive', 'module', match[1]);
   } else if (match = text.match(MODULE_CUSTOM)) {
     return makeTitle(match[3], match[2], 'module', match[1]);
-  } else if (match = text.match(MODULE_TYPE)) {
+  } else if (match = text.match(MODULE_TYPE) && doc.ngdoc === 'type') {
     return makeTitle(match[2], 'type', 'module', module || match[1]);
   } else if (match = text.match(MODULE_SERVICE)) {
     if (overview) {

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -462,7 +462,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
         module(page.moduleName || match[1], section).directives.push(page);
       } else if (match = id.match(MODULE_CUSTOM)) {
         module(page.moduleName || match[1], section).others.push(page);
-      } else if (match = id.match(MODULE_TYPE)) {
+      } else if (match = id.match(MODULE_TYPE) && page.type === 'type') {
         module(page.moduleName || match[1], section).types.push(page);
       } else if (match = id.match(MODULE_SERVICE)) {
         if (page.type === 'overview') {


### PR DESCRIPTION
Angular doesn't prohibit capitalized service names, although ngdocs does not correctly parse services with capitalized names (#77).  

This change does require capitalized `Type`s to be explicitly declared as `@ngdoc type`, although I can't find any instances of anybody actually relying on the current functionality.

I'm not particularly fond of the way that we sniff out services/types/providers/modules by using regular expressions alone.  This portion of `ngdocs.js` may need to be completely refactored at some point down the road.
