### PR TITLE
Allow "api" and so-called sections in domains, subdomains

### DIFF
--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -19,7 +19,8 @@
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
           rUrl = /(#!\/|<%= sections %>|index[^\.]*\.html).*$/,
-          baseUrl = location.origin + location.pathname.replace(rUrl, indexFile),
+          origin = location.origin,
+          baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile),
           headEl = document.getElementsByTagName('head')[0],
           sync = true;
 


### PR DESCRIPTION
Without this fix, if any string that appears in `<%= sections %>` is also in the domain or subdomains of the web server hosting ngdocs, `baseUrl` will not be correct, and all the JS and CSS resources will fail to load.

For example, we're hosting ngdocs at https://cdn-angular-api.example.com/ngdocs. Because the subdomain has "api" in it, `baseUrl` is set to `http://cdn-angular-` and all the `<link>` and `<script>` assets become 404s. 

This fixes that by not using `location.href` against the `rUrl` regex. Instead, apply `rUrl` to only the portion of the `location.href` that doesn't include `location.origin`.
