### PR TITLE
Fix bug where DOM is parsed too late.

### DIFF
--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -84,7 +84,6 @@ module.exports = function(grunt) {
     });
 
     ngdoc.merge(reader.docs);
-    ngdoc.checkBrokenLinks(reader.docs, setup.apis, options);
 
     reader.docs.forEach(function(doc){
       // this hack is here because on OSX angular.module and angular.Module map to the same file.
@@ -92,6 +91,8 @@ module.exports = function(grunt) {
           file = path.resolve(options.dest, 'partials', doc.section, id + '.html');
       grunt.file.write(file, doc.html());
     });
+
+    ngdoc.checkBrokenLinks(reader.docs, setup.apis, options);
 
     setup.pages = _.union(setup.pages, ngdoc.metadata(reader.docs));
 


### PR DESCRIPTION
When using `@link` in the following manner...

``` javascript
/**
 * {@link sc.widgets.poll.scPoller#methods_create create}
 */
```

...the `checkBrokenLinks` function is called too early.

The following logic...

``` javascript
} else if (anchorLink && linkedPage.anchors.indexOf(anchorLink) === -1) {
  console.log('WARNING: ' + doc.section + '/' + doc.id + ' (defined in ' + doc.file + ') points to a non existing anchor "' + link + '"!');
}
```

...executes before the DOM has been parsed. `linkedPage.anchors` is always `['directive', 'service', 'filter', 'function']`. When an anchor such as `#methods_create` is checked-for, it is never in `linkedPage.anchors`, and a warning is incorrectly output.

Moving the invocation of the `checkBrokenLinks` function after the call to `Doc#html` populates the `linkedPage.anchors` in-time, fixing this issue.
