### PR TITLE
RFC: Added ext as options to allow for e.g. ts files. fixes #71

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -8,8 +8,24 @@ exports.process = process;
 var ngdoc = require('./ngdoc.js'),
     NEW_LINE = /\n\r?/;
 
+function extRegex(value){
+    if(value instanceof RegExp){
+        return value;
+    } else if (typeof value === 'string') {
+        return new RegExp(value);
+    } else if (Array.isArray(value)) {
+        value = value.map(function(ext) {
+           return '(\\.' + ext + ')';
+        }).reduce(function(prev, next){
+            return prev + '|' + next;
+        }) + '$';
+        return new RegExp(value);
+    }
+}
+
 function process(content, file, section, options) {
-  if (/\.js$/.test(file)) {
+  var regex = extRegex(options.ext);
+  if (regex.test(file)) {
     processJsFile(content, file, section, options).forEach(function(doc) {
       exports.docs.push(doc);
     });

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
           startPage: '/api',
           scripts: ['angular.js'],
           styles: [],
+          ext: /(\.js)|(\.ts)$/,
           title: grunt.config('pkg') ?
             (grunt.config('pkg').title || grunt.config('pkg').name) :
             '',


### PR DESCRIPTION
Added 'ext' to options which takes either an instance of a RegExp, String or an array of strings (extensions).
This PR is mostly a request for feedback as there is currently no tests, but I wished to discuss the approach before completing the PR with tests and?

Relates to: #58 and #71 
