### PR TITLE
Adding an overflow hidden and a title to the nav module names to prevent...

### DIFF
--- a/src/templates/css/docs.css
+++ b/src/templates/css/docs.css
@@ -64,6 +64,8 @@ img.AngularJS-small {
   font-weight: bold;
   font-size: 13px;
   color: black;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .form-search > ul.nav > li > a {

--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -166,7 +166,7 @@
           <ul class="nav nav-list well" ng-repeat="module in modules track by module.url" class="api-list-item">
             <li class="nav-header module">
               <a class="guide">module</a>
-              <a class="code" href="{{module.url}}">{{module.name}}</a>
+              <a class="code" href="{{module.url}}" title="{{module.name}}">{{module.name}}</a>
             </li>
 
             <li ng-repeat="page in module.others track by page.url" ng-class="navClass(page)" class="api-list-item expand">


### PR DESCRIPTION
... the line breaking when the module name is too big,

The overflow: hidden was to stop the line breaking and the title is to improve the readability of partially hidden module names. A small change but a nice aesthetical improvement, imho! :)

P.S.: This is my first pull request and I'm not familiar with common conventions/policies. I tried looking for some sort of wiki on this project on how to contribute but I couldn't find anything. Apologies for any mistakes in advance!
