### PR TITLE
Optional links to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ ngdocs: {
     image: "path/to/my/image.png",
     imageLink: "http://my-domain.com",
     titleLink: "/api",
+    sourcePath: "http://github.com/user/my_repo/tree/master",
     bestMatch: true,
     analytics: {
           account: 'UA-08150815-0',
@@ -123,6 +124,13 @@ Wraps the title text in an anchor tag with the provided URL.
 ####imageLink
 [default] no anchor tag is used
 Wraps the navbar image in an anchor tag with the provided URL.
+
+####sourcePath
+[default] undefined
+Path to a file tree of your source code. If set, the generated docs will
+contain links to your code. GitHub-style anchors to hop to specific
+lines in files are supported, e.g. to jump directly to a function
+definition.
 
 ####bestMatch
 [default] false

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ ngdocs: {
     image: "path/to/my/image.png",
     imageLink: "http://my-domain.com",
     titleLink: "/api",
-    sourcePath: "http://github.com/user/my_repo/tree/master",
+    sourceCode: {
+      version: true
+    },
     bestMatch: true,
     analytics: {
           account: 'UA-08150815-0',
@@ -125,12 +127,50 @@ Wraps the title text in an anchor tag with the provided URL.
 [default] no anchor tag is used
 Wraps the navbar image in an anchor tag with the provided URL.
 
-####sourcePath
-[default] undefined
-Path to a file tree of your source code. If set, the generated docs will
-contain links to your code. GitHub-style anchors to hop to specific
-lines in files are supported, e.g. to jump directly to a function
-definition.
+####sourceCode
+[default] Link to a Github repo's `master` branch defined in `package.json`
+
+Adds links to view the source code from within your documentation. By default it
+is assumed that your code is accessible through GitHub and its location
+is defined in your `package.json` file (`repository.url`).
+
+Anchors to link to function, property and event definitions are set
+accordingly.
+
+This standard GitHub routine can be further customized by providing
+either
+
+``` javascript
+// Will try to read the version property of your package.json file
+// and link to code available at the time of this release
+sourceCode: {
+  version: true
+}
+```
+or
+``` javascript
+// Will link to the code at the exact point in time the documentation is
+// built, referencing the git tree by the current commit sha
+sourceCode: {
+  version: 'sha'
+}
+```
+
+If your source code is not available through GitHub a custom path to
+your file tree can be given - take note that in this case you need to
+handle versioning yourself.
+
+``` javascript
+sourceCode: {
+  path: 'http://www.my-code.com'
+  anchorPrefix: 'anchor' // optional prefix to the line number
+}
+```
+
+To disable this feature altogether, use:
+``` javascript
+sourceCode: false
+```
 
 ####bestMatch
 [default] false

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "marked": "~0.3.2"
+    "marked": "~0.3.2",
+    "shelljs": "^0.3.0"
   },
   "peerDependencies": {
     "grunt": "0.4.x"

--- a/src/dom.js
+++ b/src/dom.js
@@ -42,12 +42,12 @@ function normalizeHeaderToId(header) {
 }
 
 
-function DOM(sourcePath) {
+function DOM(sourceCode) {
   this.out = [];
   this.headingDepth = 0;
   this.currentHeaders = [];
   this.anchors = [];
-  this.sourcePath = sourcePath;
+  this.sourceCode = sourceCode;
 }
 
 var INLINE_TAGS = {
@@ -123,9 +123,10 @@ DOM.prototype = {
   },
 
   sourceLink: function(file, line, showText, noMargin) {
-    if (this.sourcePath) {
+    if (this.sourceCode) {
       var iconText = ' ';
-      var href = this.sourcePath + '/' + file + '#L' + line;
+      var href = this.sourceCode.path + '/' +
+        file + '#' + this.sourceCode.anchorPrefix + line;
       var text = 'View Source';
       var attrs = {
         'href': href,

--- a/src/dom.js
+++ b/src/dom.js
@@ -124,7 +124,7 @@ DOM.prototype = {
 
   sourceLink: function(file, line, showText, noMargin) {
     if (this.sourcePath) {
-      var iconText;
+      var iconText = ' ';
       var href = this.sourcePath + '/' + file + '#L' + line;
       var text = 'View Source';
       var attrs = {
@@ -133,8 +133,9 @@ DOM.prototype = {
       };
       if (noMargin) attrs.style = "margin: 0";
       if (showText) {
-        iconText = ' ' + text;
+        iconText += text;
       } else {
+
         attrs.title = text;
       }
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -42,11 +42,12 @@ function normalizeHeaderToId(header) {
 }
 
 
-function DOM() {
+function DOM(sourcePath) {
   this.out = [];
   this.headingDepth = 0;
   this.currentHeaders = [];
   this.anchors = [];
+  this.sourcePath = sourcePath;
 }
 
 var INLINE_TAGS = {
@@ -119,6 +120,28 @@ DOM.prototype = {
 
   div: function(attr, text) {
     this.tag('div', attr, text);
+  },
+
+  sourceLink: function(file, line, showText, noMargin) {
+    if (this.sourcePath) {
+      var iconText;
+      var href = this.sourcePath + '/' + file + '#L' + line;
+      var text = 'View Source';
+      var attrs = {
+        'href': href,
+        'class': 'source-link',
+      };
+      if (noMargin) attrs.style = "margin: 0";
+      if (showText) {
+        iconText = ' ' + text;
+      } else {
+        attrs.title = text;
+      }
+
+      this.tag('a', attrs, function() {
+        this.tag('i', { 'class': 'icon-eye-open' }, iconText);
+      });
+    }
   },
 
   h: function(heading, content, fn){

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -501,6 +501,7 @@ Doc.prototype = {
       dom.text(' Improve this doc');
     });
     */
+    dom.sourceLink(this.file, this.codeLine, true, true);
     dom.h(title(this), function() {
       notice('deprecated', 'Deprecated API', self.deprecated);
       if (self.ngdoc === 'error') {
@@ -896,6 +897,7 @@ Doc.prototype = {
         dom.h('Methods', self.methods, function(method){
           //filters out .IsProperty parameters from the method signature
           var signature = (method.param || []).filter(function(e) { return e.isProperty !== true; }).map(property('name'));
+          dom.sourceLink(method.file, method.codeLine);
           dom.h(method.shortName + '(' + signature.join(', ') + ')', method, function() {
             dom.html(method.description);
             method.html_usage_parameters(dom);

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -467,8 +467,8 @@ Doc.prototype = {
     }
   },
 
-  html: function() {
-    var dom = new DOM(),
+  html: function(sourcePath) {
+    var dom = new DOM(sourcePath),
       self = this,
       minerrMsg;
 

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -467,8 +467,8 @@ Doc.prototype = {
     }
   },
 
-  html: function(sourcePath) {
-    var dom = new DOM(sourcePath),
+  html: function(sourceCode) {
+    var dom = new DOM(sourceCode),
       self = this,
       minerrMsg;
 

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -363,7 +363,9 @@ Doc.prototype = {
     var atText;
     var match;
     var self = this;
-    self.text.split(NEW_LINE).forEach(function(line){
+    var lines = self.text.split(NEW_LINE);
+    self.codeLine = self.line + lines.length + 1;
+    lines.forEach(function(line){
       if ((match = line.match(/^\s*@(\w+)(\s+(.*))?/))) {
         // we found @name ...
         // if we have existing name

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -912,6 +912,13 @@ Doc.prototype = {
     if (self.properties.length) {
       dom.div({class:'member property'}, function(){
         dom.h('Properties', self.properties, function(property){
+          // We can only link to the source code, when we are looking
+          // at a property, that was defined with @ngdoc (as opposed to
+          // a definition through @property). Only then we know the location
+          // of this specific property.
+          if (property.file) {
+            dom.sourceLink(property.file, property.codeLine);
+          }
           dom.h(property.shortName, function() {
             dom.html(property.description);
             if (!property.html_usage_returns) {

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -54,7 +54,7 @@ var BOOLEAN_ATTR = {};
 });
 
 //////////////////////////////////////////////////////////
-function Doc(text, file, line, options) {
+function Doc(text, file, startLine, endLine, options) {
   if (typeof text == 'object') {
     for ( var key in text) {
       this[key] = text[key];
@@ -62,7 +62,8 @@ function Doc(text, file, line, options) {
   } else {
     this.text = text;
     this.file = file;
-    this.line = line;
+    this.line = startLine;
+    this.codeLine = endLine + 1;
   }
   this.options = options || {};
   this.scenarios = this.scenarios || [];
@@ -364,7 +365,6 @@ Doc.prototype = {
     var match;
     var self = this;
     var lines = self.text.split(NEW_LINE);
-    self.codeLine = self.line + lines.length + 1;
     lines.forEach(function(line){
       if ((match = line.match(/^\s*@(\w+)(\s+(.*))?/))) {
         // we found @name ...

--- a/src/reader.js
+++ b/src/reader.js
@@ -11,7 +11,7 @@ var ngdoc = require('./ngdoc.js'),
 function process(content, file, section, options) {
   if (file.match(/\.ngdoc$/)) {
     var header = '@section ' + section + '\n';
-    exports.docs.push(new ngdoc.Doc(header + content.toString(),file, 1, options).parse());
+    exports.docs.push(new ngdoc.Doc(header + content.toString(),file, 1, null, options).parse());
   } else {
     processJsFile(content, file, section, options).forEach(function(doc) {
       exports.docs.push(doc);
@@ -42,7 +42,7 @@ function processJsFile(content, file, section, options) {
       text = text.replace(/^\n/, '');
       if (text.match(/@ngdoc/)){
         //console.log(file, startingLine)
-        docs.push(new ngdoc.Doc('@section ' + section + '\n' + text, file, startingLine, options).parse());
+        docs.push(new ngdoc.Doc('@section ' + section + '\n' + text, file, startingLine, lineNumber, options).parse());
       }
       doc = null;
       inDoc = false;

--- a/src/templates/css/docs.css
+++ b/src/templates/css/docs.css
@@ -223,6 +223,11 @@ ul.events > li > h3 {
   font-family: monospace;
 }
 
+.source-link {
+  margin: -.7rem;
+  float: right;
+}
+
 .center {
   display: block;
   margin: 2em auto;

--- a/src/templates/css/docs.css
+++ b/src/templates/css/docs.css
@@ -224,7 +224,7 @@ ul.events > li > h3 {
 }
 
 .source-link {
-  margin: -.7rem;
+  margin: -.7rem 0;
   float: right;
 }
 

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
       // this hack is here because on OSX angular.module and angular.Module map to the same file.
       var id = doc.id.replace('angular.Module', 'angular.IModule').replace(':', '.'),
           file = path.resolve(options.dest, 'partials', doc.section, id + '.html');
-      grunt.file.write(file, doc.html());
+      grunt.file.write(file, doc.html(options.sourcePath));
     });
 
     ngdoc.checkBrokenLinks(reader.docs, setup.apis, options);

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
     grunt.log.writeln('Generating Documentation...');
 
     if (srcCode) {
-      grunt.log.writeln( 'Generating source code links to ' + srcCode.path);
+      grunt.log.writeln( '... with source code links to ' + srcCode.path);
     }
 
     reader.docs = [];
@@ -130,45 +130,49 @@ module.exports = function(grunt) {
 
       var repo = pkg.repository;
       var path, treeRef;
-      var warning = 'No path to source repo found. Building without source links.'
+      var warning = 'No path to source repo found. Building without source links.';
 
       if (!(repo && repo.type == 'git')) {
         log(warning);
         return;
       }
 
-      var url = repo.url;
-      if (url) {
-        var match =  url.match(/git@github.com:(.*)\.git/);
-        if (match) {
-          path = 'http://github.com/' + match[1];
-        } else {
-          if (url.match(/https?:\/\/github.com/)) {
-            path = url;
-          }
-        }
-      }
+      path = parseSourceCodePath(repo.url);
 
       if (!path) {
         log(warning);
         return;
       }
 
-      if (opt.version) {
-        if (opt.version === 'sha') {
-          var shell = require('shelljs');
-          var sha = shell.exec('git rev-parse HEAD', { silent: true });
-          treeRef = sha.output;
-        } else {
-          treeRef = 'v' + pkg.version;
-        }
-      }
-      treeRef = treeRef || 'master';
+      treeRef = parseSourceCodeVersion(opt.version, pkg);
 
       opt.path = path + '/tree/' + treeRef;
       opt.anchorPrefix = opt.anchorPrefix || 'L';
 
       return opt;
+    }
+  }
+
+  function parseSourceCodeVersion(version, pkg) {
+    if (!version) return 'master';
+    if (version === 'sha') {
+      var shell = require('shelljs');
+      var sha = shell.exec('git rev-parse HEAD', { silent: true });
+      return sha.output;
+    } else {
+      return 'v' + pkg.version;
+    }
+  }
+
+  function parseSourceCodePath(url) {
+    if (!url) return;
+    var match =  url.match(/git@github.com:(.*)\.git/);
+    if (match) {
+      return 'http://github.com/' + match[1];
+    } else {
+      if (url.match(/https?:\/\/github.com/)) {
+        return url;
+      }
     }
   }
 


### PR DESCRIPTION
Picks up #25 

Adds support to optionally add source code links to the generated docs. They are present on several levels: To definitions of services/directives/filters, but also to individual methods/functions and properties (as long as they were defined with `@ngdoc`.

This is achieved by adding a `sourcePath` property to the ngdocs options in your Gruntfile. The path should be the root of your file tree. This is obviously targetted at pointing to a github repository - internal repositories can still be supported when someone points to a local file tree, but that probably means some work on the users side.

Right now the anchor tags are styled in GitHub's way (line numbers prefixed by an `L`, as in: `L27`). We can probably discuss to allow custom prefixes and only use `L` as default. One could also pass an object as `sourcePath`, something like
```
"sourcePath" : {
   "path": "http://path.to.file.tree",
   "anchorPrefix" : "myPrefix"
}
``` 
but it's a feature probably not really needed - not sure.

When no `sourcePath` is given in the Gruntfile, no links are added - the generated docs look exactly like before.

Take note that [https://github.com/LFDM/grunt-ngdocs/blob/d44d1d31f4cb5b326f7e9b7cbb6acfde495f196d/src/ngdoc.js#L504](this line) looks a bit silly, but it was the fastest way to get to nicely styled html... ;)


Here are some screenshots:

- A doc page with source links

![grunt-ngdocs1](https://cloud.githubusercontent.com/assets/2204549/5405899/b0b41dba-81ab-11e4-9dbf-710652995959.png)

- And this is where I arrive when I click the eye icon next to `addClickAction` - I have pointed my `sourcePath` to my GithubRepo, specifically to http://github.com/latin-language-toolkit/arethusa/tree/doc

![grunt-ngdocs2](https://cloud.githubusercontent.com/assets/2204549/5405916/f855ecb6-81ab-11e4-9d7c-5480b34a6659.png)
