### PR TITLE
Adds animate bool to config

### DIFF
--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -518,7 +518,20 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
   }
 };
 
-angular.module('docsApp', ['ngAnimate', 'bootstrap', 'bootstrapPrettify']).
+/**********************************
+ Build Deps
+***********************************/
+exports.buildDeps = buildDeps;
+
+function buildDeps() {
+  if (NG_DOCS.animate) {
+   return ['ngAnimate', 'bootstrap', 'bootstrapPrettify']
+  } else {
+   return ['bootstrap', 'bootstrapPrettify']
+  }
+};
+
+angular.module('docsApp', buildDeps()).
   config(function($locationProvider) {
     if (NG_DOCS.html5Mode) {
       $locationProvider.html5Mode(true).hashPrefix('!');

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -27,6 +27,7 @@ module.exports = function(grunt) {
             (grunt.config('pkg').title || grunt.config('pkg').name) :
             '',
           html5Mode: true,
+          animate: true,
           editExample: true
         }),
         section = this.target === 'all' ? 'api' : this.target,
@@ -152,6 +153,7 @@ module.exports = function(grunt) {
 
     // create setup file
     setup.html5Mode = options.html5Mode;
+    setup.animate = options.animate;
     setup.editExample = options.editExample;
     setup.startPage = options.startPage;
     setup.discussions = options.discussions;


### PR DESCRIPTION
I've currently removed angular-animate from all of my projects, but am still using ngDocs. I really don't want to have to include a module like this for my docs. IMO this is a nice-to-have for my documentation and shouldn't be a requirement. I added a new bool `animate: bool`  option to the config. It defaults to true, but if set to false removes the module from the array of dependencies. 