### PR TITLE
Regression against v0.1.1 where 'file:' protocol is not supported any more

### DIFF
--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -19,8 +19,7 @@
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
           rUrl = /(#!\/|<%= sections %>|index[^\.]*\.html).*$/,
-          origin = location.origin || (window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '')),
-          baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile),
+          baseUrl = location.href.replace(rUrl, indexFile),
           headEl = document.getElementsByTagName('head')[0],
           sync = true;
 


### PR DESCRIPTION
With ngdocs 0.2.7, opening local docs using file protocol results in a non-rendered page. This is disappointing for new users. I don't think it is compulsory to have a server to host the documentation before I see the docs properly.