### PR TITLE
Added template configurability

### DIFF
--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -202,11 +202,12 @@ module.exports = function(grunt) {
           titleLink: options.titleLink,
           imageLink: options.imageLink,
           bestMatch: options.bestMatch,
-          deferLoad: !!options.deferLoad
+          deferLoad: !!options.deferLoad,
+          template: options.template ? options.template : path.resolve(templates, 'index.tmpl')
         };
 
     // create index.html
-    content = grunt.file.read(path.resolve(templates, 'index.tmpl'));
+    content = grunt.file.read(options.template);
     content = grunt.template.process(content, {data:data});
     grunt.file.write(path.resolve(options.dest, 'index.html'), content);
 


### PR DESCRIPTION
- In order not to be forced to use the default index.tmpl it is now possible to use your own .tmpl file
- This option allows you to define, e.g. which .css files you want to load inside of the .tmpl
- As fallback the default index.tmpl will be used

Usage:
1. Define your own .tmpl file.
2. In your options config-object add the option 'template' and define the path to your own .tmpl file. It should look like this:
options: {
        html5Mode: false,
        animation: false,
        ...
        template: 'config/../../own.tmpl',
    },
3. That's all!