### PR TITLE
Inline partials to allow opening docs from the file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ ngdocs: {
     image: "path/to/my/image.png",
     imageLink: "http://my-domain.com",
     titleLink: "/api",
+    inlinePartials: true,
     bestMatch: true,
     analytics: {
           account: 'UA-08150815-0',
@@ -201,6 +202,11 @@ Display "Improve this doc" link. Same options as for sourceLink.
 
 Show Edit Button for examples.
 
+#### inlinePartials
+[default] false
+
+If set to true this option will turn all partials into angular inline templates and place them inside the generated `index.html` file.
+The advantage over lazyloading with ajax is that the documentation will also work on the `file://` system.
 
 #### discussions
 Optional include [discussions](http://disqus.com) in the documentation app.

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -35,7 +35,8 @@ module.exports = function(grunt) {
           html5Mode: false,
           editExample: true,
           sourceLink: true,
-          editLink: true
+          editLink: true,
+          inlinePartials: false
         }),
         section = this.target === 'all' ? 'api' : this.target,
         setup;
@@ -114,6 +115,10 @@ module.exports = function(grunt) {
     }
 
     writeSetup(setup);
+
+    if (options.inlinePartials) {
+      inlinePartials(path.resolve(options.dest, 'index.html'), path.resolve(options.dest, 'partials'));
+    }
 
     grunt.log.writeln('DONE. Generated ' + reader.docs.length + ' pages in ' + (now()-start) + 'ms.');
     done();
@@ -229,6 +234,38 @@ module.exports = function(grunt) {
         } else {
           grunt.file.copy(src, dest);
         }
+    });
+  }
+
+  function inlinePartials(indexFile, partialsFolder) {
+    var indexFolder = path.dirname(indexFile);
+    var partials = grunt.file.expand(partialsFolder + '/**/*.html').map(function(partial){
+      return path.relative(indexFolder, partial);
+    });
+    var html = partials.map(function(partial){
+      // Get the partial content and replace the closing script tags with a placeholder
+      var partialContent = grunt.file.read(path.join(indexFolder, partial))
+        .replace(/<\/script>/g, '<___/script___>');
+      return '<script type="text/ng-template" id="' + partial + '">' + partialContent + '<' + '/script>';
+    }).join('');
+    // During page initialization replace the placeholder back to the closing script tag
+    // @see https://github.com/angular/angular.js/issues/2820
+    html += '<script>(' + (function() { 
+      var scripts = document.getElementsByTagName("script");
+      for (var i=0;i<scripts.length;i++) {
+        if (scripts[i].type==='text/ng-template') {
+          scripts[i].innerHTML = scripts[i].innerHTML.replace(/<___\/script___>/g, '</' + 'script>');
+        }
+      }
+    }) + '())</script>';
+    // Inject the html into the ngdoc file
+    var patchedIndex = grunt.file.read(indexFile).replace(/<body[^>]*>/i, function(match) {
+      return match + html;
+    });
+    grunt.file.write(indexFile, patchedIndex);
+    // Remove the partials
+    partials.forEach(function(partial) {
+      grunt.file.delete(path.join(indexFolder, partial));
     });
   }
 


### PR DESCRIPTION
Hi,

I am sending our docs to a customer and would prefer if he could see the result without launching up a dev server.

This pull request inlines all partials as `<script type="text/ng-template"></script>` templates and injects them right after the body tag so ajax calls aren't necessary anymore and the docs can be opened from the file system.

Unfortunately the browser got mixed up if the partial contained closing script tags. That's why the pull request is a little bit bigger than intended as the pull request has to escape all closing script tags `</script>` and unescape them again.

This feature is disabled by default - to use it you have to set `inlinePartials` to `true`.

What do you think?