### PR TITLE
Changelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,19 @@ module.exports = function (grunt) {
       release: {
         src: 'CHANGELOG.md'
       }
+    },
+    conventionalGithubReleaser: {
+      release: {
+        options: {
+          auth: {
+            type: 'oauth',
+            token: process.env.GH_TOKEN
+          },
+          changelogOpts: {
+            preset: 'angular'
+          }
+        }
+      }
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,16 @@ module.exports = function (grunt) {
         files: ['src/*.js', 'spec/*Spec.js'],
         tasks: ['jasmine_node']
       }
+    },
+    conventionalChangelog: {
+      options: {
+        changelogOpts: {
+          preset: 'angular'
+        }
+      },
+      release: {
+        src: 'CHANGELOG.md'
+      }
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-conventional-changelog": "~0.1.0",
+    "grunt-conventional-changelog": "~4.1.0",
     "grunt-contrib-watch": "~0.5.0",
     "grunt-jasmine-node": "~0.1.0",
     "jasmine-node": "~1.12.0"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-conventional-changelog": "~4.1.0",
     "grunt-contrib-watch": "~0.5.0",
+    "grunt-conventional-changelog": "~4.1.0",
+    "grunt-conventional-github-releaser": "^0.4.0",
     "grunt-jasmine-node": "~0.1.0",
     "jasmine-node": "~1.12.0"
   }


### PR DESCRIPTION
chore(build): update grunt-conventional-changelog
The old grunt-conventional-changelog is buggy and no features.
feat(build): use grunt-conventional-github-releaser
You need to setup environment variable GH_TOKEN as your GitHub token.