### PR TITLE
External Examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ngdocs",
-  "version": "0.2.9",
+  "version": "0.2.9-1",
   "description": "grunt plugin for angularjs documentation",
   "main": "tasks",
   "repository": {

--- a/src/reader.js
+++ b/src/reader.js
@@ -1,56 +1,148 @@
 /**
  * All reading related code here.
  */
-
-exports.docs = [];
-exports.process = process;
-
+var path = require('path');
 var ngdoc = require('./ngdoc.js'),
-    NEW_LINE = /\n\r?/;
+    NEW_LINE = /\n\r?/,
+    DEFAULT_EXAMPLES_DIR = 'examples';
 
-function process(content, file, section, options) {
-  if (file.match(/\.ngdoc$/)) {
-    var header = '@section ' + section + '\n';
-    exports.docs.push(new ngdoc.Doc(header + content.toString(),file, 1, 1, options).parse());
-  } else {
-    processJsFile(content, file, section, options).forEach(function(doc) {
-      exports.docs.push(doc);
+module.exports = Reader;
+
+function Reader(grunt) {
+  var self = this;
+
+  self.docs = [];
+  self.process = process;
+
+  function process(content, file, section, options) {
+    if (file.match(/\.ngdoc$/)) {
+      var header = '@section ' + section + '\n';
+      self.docs.push(new ngdoc.Doc(header + content.toString(),file, 1, 1, options).parse());
+    } else {
+      processJsFile(content, file, section, options).forEach(function(doc) {
+        self.docs.push(doc);
+      });
+    }
+  }
+
+  function processJsFile(content, file, section, options) {
+    var docs = [];
+    var lines = content.toString().split(NEW_LINE);
+    var text;
+    var startingLine ;
+    var match;
+    var inDoc = false;
+
+    lines.forEach(function(line, lineNumber){
+      lineNumber++;
+      // is the comment starting?
+      if (!inDoc && (match = line.match(/^\s*\/\*\*\s*(.*)$/))) {
+        line = match[1];
+        inDoc = true;
+        text = [];
+        startingLine = lineNumber;
+      }
+
+      // are we done?
+      else if (inDoc && line.match(/\*\//)) {
+        text = text.join('\n');
+        text = text.replace(/^\n/, '');
+        if (text.match(/@ngdoc/)){
+          //console.log(file, startingLine)
+          docs.push(new ngdoc.Doc('@section ' + section + '\n' + text, file, startingLine, lineNumber, options).parse());
+        }
+        doc = null;
+        inDoc = false;
+      }
+
+      else if (inDoc && (match = line.match(/@external-example:(.+)/))) {
+        if (match && match.length > 1) {
+          handleExternalExample(line, match, text, options);
+        }
+      }
+
+      // is the comment add text
+      else if (inDoc){
+        text.push(line.replace(/^\s*\*\s?/, ''));
+      }
     });
+    return docs;
+  }
+
+  function handleExternalExample(line, match, text, options) {
+    var baseExampleDir = options.examplesDir || DEFAULT_EXAMPLES_DIR;
+
+    var exampleName = match[1];
+    var exampleDir = '';
+    var exampleContent = '';
+
+    var pattern = baseExampleDir + '/**/' + exampleName.replace(/\./g, '/');
+    var exampleDirs = grunt.file.expand(pattern);
+
+    if (exampleDirs && exampleDirs.length) {
+      exampleDir = path.resolve(exampleDirs[0]);
+    }
+
+    if (exampleDir && grunt.file.exists(exampleDir) && grunt.file.isDir(exampleDir)) {
+      grunt.file.recurse(exampleDir, function(fileAbsPath, rootDir, fileDir, fileName) {
+        var fileContent = grunt.file.read(fileAbsPath);
+
+        if (fileContent) {
+          exampleContent += '\n\r<file name="' + fileName + '">\n\r';
+          exampleContent += processExampleFile(fileContent, fileName);
+          exampleContent += '\n\r</file>\n\r';
+        }
+      });
+    }
+
+    if (exampleContent) {
+      exampleContent = '<example module="' + exampleName + '">' + exampleContent + '</example>';
+      text.push(exampleContent);
+    }
+  }
+
+  function processExampleFile(fileContent, fileName) {
+    var proccessedContent = processBasicExample(fileContent);
+
+    var fileExt = fileName.split(/\./).pop();
+
+    if (fileExt === 'html') {
+      proccessedContent = processHtmlExample(proccessedContent);
+    }
+
+    return proccessedContent;
+  }
+
+  function processBasicExample(fileContent) {
+    var processedContent = '';
+
+    var exampleLines = fileContent.toString().split(NEW_LINE);
+
+    exampleLines.forEach(function(line) {
+      processedContent += line + '\n\r';
+    });
+
+    return processedContent;
+  }
+
+  function processHtmlExample(fileContent) {
+    var processedContent = '';
+    var bodyFound = false;
+
+    var exampleLines = fileContent.toString().split(NEW_LINE);
+
+    exampleLines.forEach(function(line) {
+      if (line.match(/^\s*<body.*>\s*$/)) {
+        bodyFound = true;
+      } else if (line.match(/^\s*<\/body>\s*$/)) {
+        bodyFound = false;
+      } else if (bodyFound && !line.match(/^.*<script.*$/)) {
+        processedContent += line + '\n\r';
+      }
+    });
+
+    return processedContent;
   }
 }
 
-function processJsFile(content, file, section, options) {
-  var docs = [];
-  var lines = content.toString().split(NEW_LINE);
-  var text;
-  var startingLine ;
-  var match;
-  var inDoc = false;
 
-  lines.forEach(function(line, lineNumber){
-    lineNumber++;
-    // is the comment starting?
-    if (!inDoc && (match = line.match(/^\s*\/\*\*\s*(.*)$/))) {
-      line = match[1];
-      inDoc = true;
-      text = [];
-      startingLine = lineNumber;
-    }
-    // are we done?
-    if (inDoc && line.match(/\*\//)) {
-      text = text.join('\n');
-      text = text.replace(/^\n/, '');
-      if (text.match(/@ngdoc/)){
-        //console.log(file, startingLine)
-        docs.push(new ngdoc.Doc('@section ' + section + '\n' + text, file, startingLine, lineNumber, options).parse());
-      }
-      doc = null;
-      inDoc = false;
-    }
-    // is the comment add text
-    if (inDoc){
-      text.push(line.replace(/^\s*\*\s?/, ''));
-    }
-  });
-  return docs;
-}

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 
-var reader = require('../src/reader.js'),
+var Reader = require('../src/reader.js'),
     ngdoc = require('../src/ngdoc.js'),
     path = require('path'),
     vm = require('vm');
@@ -20,6 +20,8 @@ var repohosts = [
 ];
 
 module.exports = function(grunt) {
+  var reader = new Reader(grunt);
+
   var _ = grunt.util._,
       unittest = {},
       templates = path.resolve(__dirname, '../src/templates');


### PR DESCRIPTION
We found it too cumbersome to write the actual example code/files inline in the documentation markdown.

We thought that being able to have the examples in external files on the filesystem, could be better due to several reasons:

1. Using external files, one could test these examples independently from the ngdocs mechanism. They would be little, actual, runnable web applications.
2. Much easier to write code and markup in real files.
3. Much easier to read the source files later, when the documentation blocks are not massive.
4. Easier to maintain.

The path we took is defining a new annotation, called '@external-example' which is in fact parsed by the grunt-ngdocs plugin.
The hint given to this annotation, i.e. '@external-example:my.example' will look for a directory named 'my/example/ under the base examples directory in the project (by default, a directory named 'examples' under the root dir). All of the files in this example directory will become <file> blocks in the markdown.

Moreover, if the index.html of the example is in fact a full-blown HTML (with <head> and other resources) - the '@external-example' would know to take only the <body> section, since the HTML in the embedded documentation would be generated automatically later.

The base examples directory can be configured in the grunt-ngdocs plugin, the following way:

ngdocs: {
  options: {
    examplesDir: "my-custom-examples-dir"
  }
}

I hope this is clear and useful to others.
Thanks in any case,
Daniel