### PR TITLE
Fix #199 normalize path for different platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "marked": "~0.3.2",
-    "shelljs": "~0.3.0"
+    "shelljs": "~0.3.0",
+    "upath": "~0.2.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -9,6 +9,7 @@
 var reader = require('../src/reader.js'),
     ngdoc = require('../src/ngdoc.js'),
     path = require('path'),
+    upath = require('upath'),
     vm = require('vm');
 
 var repohosts = [
@@ -257,7 +258,7 @@ module.exports = function(grunt) {
       // Get the partial content and replace the closing script tags with a placeholder
       var partialContent = grunt.file.read(path.join(indexFolder, partial))
         .replace(/<\/script>/g, '<___/script___>');
-      return '<script type="text/ng-template" id="' + partial + '">' + partialContent + '<' + '/script>';
+      return '<script type="text/ng-template" id="' + upath.normalize(partial) + '">' + partialContent + '<' + '/script>';
     }).join('');
     // During page initialization replace the placeholder back to the closing script tag
     // @see https://github.com/angular/angular.js/issues/2820


### PR DESCRIPTION
Npm package [page](https://www.npmjs.com/package/upath) to normalize path for UNIX and Windows machines