### PR TITLE
Feature/component support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -287,14 +287,39 @@ Doc.prototype = {
             (title || url).replace(/^#/g, '').replace(/\n/g, ' ') +
             (isAngular ? '</code>' : '') +
             '</a>';
-        }).
-        replace(/{@type\s+(\S+)(?:\s+(\S+))?}/g, function(_, type, url) {
-          url = url || '#';
-          return '<a href="' + url + '" class="' + self.prepare_type_hint_class_name(type) + '">' + type + '</a>';
-        }).
-        replace(/{@installModule\s+(\S+)?}/g, function(_, module) {
-          return explainModuleInstallation(module);
+      }).
+      replace(/{@type\s+(\S+)(?:\s+(\S+))?}/g, function(_, type, url) {
+        url = url || '#';
+        return '<a href="' + url + '" class="' + self.prepare_type_hint_class_name(type) + '">' + type + '</a>';
+      }).
+      replace(/{@installModule\s+(\S+)?}/g, function(_, module) {
+        return explainModuleInstallation(module);
+      });
+
+      if(self.options.highlightCodeFences) {
+        parts[i] = parts[i].replace(/^```([+-]?)([a-z]*)([\s\S]*?)```/i, function(_, alert, type, content){
+          var tClass = 'prettyprint linenums';
+
+          // check if alert type is set - if true, add the corresponding
+          // bootstrap classes
+          if(alert) {
+            tClass += ' alert alert-' + (alert === '+' ? 'success' : 'danger');
+          }
+
+          // if type is set, add lang-* information for google code
+          // prettify - normally this is not necessary, because the prettifier
+          // tries to guess the language.
+          if(type) {
+            tClass += ' lang-' + type;
+          }
+
+          return placeholder(
+              '<pre class="' + tClass + '">' +
+              content.replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+              '</pre>');
         });
+
+      }
     });
     text = parts.join('');
 
@@ -660,6 +685,91 @@ Doc.prototype = {
     }
   },
 
+  html_usage_bindings: function(dom) {
+    var self = this;
+    var params = this.param ? this.param : [];
+    if(this.animations) {
+      dom.h('Animations', this.animations, function(animations){
+        dom.html('<ul>');
+        var animations = animations.split("\n");
+        animations.forEach(function(ani) {
+          dom.html('<li>');
+          dom.text(ani);
+          dom.html('</li>');
+        });
+        dom.html('</ul>');
+      });
+      // dom.html('<a href="api/ngAnimate.$animate">Click here</a> to learn more about the steps involved in the animation.');
+    }
+    if(params.length > 0) {
+      dom.html('<h2>Bindings</h2>');
+      dom.html('<table class="variables-matrix table table-bordered table-striped">');
+      dom.html('<thead>');
+      dom.html('<tr>');
+      dom.html('<th>Binding</th>');
+      dom.html('<th>Type</th>');
+      dom.html('<th>Details</th>');
+      dom.html('</tr>');
+      dom.html('</thead>');
+      dom.html('<tbody>');
+      processParams(params);
+      function processParams(params) {
+        for(var i=0;i<params.length;i++) {
+          param = params[i];
+          var name = param.name;
+          var types = param.type;
+          if(types[0]=='(') {
+            types = types.substr(1);
+          }
+
+          var limit = types.length - 1;
+          if(types.charAt(limit) == ')' && types.charAt(limit-1) != '(') {
+            types = types.substr(0,limit);
+          }
+          types = types.split(/\|(?![\(\)\w\|\s]+>)/);
+          if (param.optional) {
+            name += ' <div><em>(optional)</em></div>';
+          }
+          dom.html('<tr>');
+          dom.html('<td>' + name + '</td>');
+          dom.html('<td>');
+          for(var j=0;j<types.length;j++) {
+            var type = types[j];
+            dom.html('<a href="" class="' + self.prepare_type_hint_class_name(type) + '">');
+            dom.text(type);
+            dom.html('</a>');
+          }
+
+          dom.html('</td>');
+          dom.html('<td>');
+          dom.html(param.description);
+          if (param.default) {
+            dom.html(' <p><em>(default: ' + param.default + ')</em></p>');
+          }
+          if (param.properties) {
+            //            dom.html('<table class="variables-matrix table table-bordered table-striped">');
+            dom.html('<table>');
+            dom.html('<thead>');
+            dom.html('<tr>');
+            dom.html('<th>Property</th>');
+            dom.html('<th>Type</th>');
+            dom.html('<th>Details</th>');
+            dom.html('</tr>');
+            dom.html('</thead>');
+            dom.html('<tbody>');
+            processParams(param.properties);
+            dom.html('</tbody>');
+            dom.html('</table>');
+          }
+          dom.html('</td>');
+          dom.html('</tr>');
+        };
+      }
+      dom.html('</tbody>');
+      dom.html('</table>');
+    }
+  },
+
   html_usage_returns: function(dom) {
     var self = this;
     if (self.returns) {
@@ -972,6 +1082,7 @@ Doc.prototype = {
     this.html_usage_interface(dom)
   },
 
+
   method_properties_events: function(dom) {
     var self = this;
     if (self.methods.length) {
@@ -1060,8 +1171,8 @@ Doc.prototype = {
 var GLOBALS = /^angular\.([^\.]+)$/,
     MODULE = /^([^\.]+)$/,
     MODULE_MOCK = /^angular\.mock\.([^\.]+)$/,
-    MODULE_COMPONENT = /^(.+)\.components?:([^\.]+)$/,
     MODULE_CONTROLLER = /^(.+)\.controllers?:([^\.]+)$/,
+    MODULE_COMPONENT = /^(.+)\.components?:([^\.]+)$/,
     MODULE_DIRECTIVE = /^(.+)\.directives?:([^\.]+)$/,
     MODULE_DIRECTIVE_INPUT = /^(.+)\.directives?:input\.([^\.]+)$/,
     MODULE_CUSTOM = /^(.+)\.([^\.]+):([^\.]+)$/,
@@ -1110,10 +1221,10 @@ function title(doc) {
     return makeTitle(overview ? '' : match[1], '', 'module', match[1]);
   } else if (match = text.match(MODULE_MOCK)) {
     return makeTitle('angular.mock.' + match[1], 'API', 'module', 'ng');
-  } else if (match = text.match(MODULE_COMPONENT)) {
-    return makeTitle(match[2], 'component', 'module', match[1]);
   } else if (match = text.match(MODULE_CONTROLLER) && doc.type === 'controller') {
     return makeTitle(match[2], 'controller', 'module', match[1]);
+  } else if (match = text.match(MODULE_COMPONENT)) {
+    return makeTitle(match[2], 'component', 'module', match[1]);
   } else if (match = text.match(MODULE_DIRECTIVE)) {
     return makeTitle(match[2], 'directive', 'module', match[1]);
   } else if (match = text.match(MODULE_DIRECTIVE_INPUT)) {

--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -177,6 +177,13 @@
               <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
             </li>
 
+            <li class="nav-header section" ng-show="module.components.length">
+              <a class="guide">component</a>
+            </li>
+            <li ng-repeat="page in module.components track by page.url" ng-class="navClass(page)" class="api-list-item expand">
+              <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
+            </li>
+
             <li class="nav-header section" ng-show="module.directives.length">
               <a class="guide">directive</a>
             </li>

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -231,6 +231,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
       GLOBALS = /^angular\.([^\.]+)$/,
       MODULE = /^([^\.]+)$/,
       MODULE_MOCK = /^angular\.mock\.([^\.]+)$/,
+      MODULE_COMPONENT = /^(.+)\.components?:([^\.]+)$/,
       MODULE_CONTROLLER = /^(.+)\.controllers?:([^\.]+)$/,
       MODULE_DIRECTIVE = /^(.+)\.directives?:([^\.]+)$/,
       MODULE_DIRECTIVE_INPUT = /^(.+)\.directives?:input\.([^\.]+)$/,
@@ -409,6 +410,8 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
         module(page.moduleName || match[1], section);
       } else if (match = id.match(MODULE_FILTER)) {
         module(page.moduleName || match[1], section).filters.push(page);
+      } else if (match = id.match(MODULE_COMPONENT)) {
+        module(page.moduleName || match[1], section).components.push(page);
       } else if (match = id.match(MODULE_CONTROLLER) && page.type === 'controller') {
         module(page.moduleName || match[1], section).controllers.push(page);
       } else if (match = id.match(MODULE_DIRECTIVE)) {
@@ -453,6 +456,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, section
           name: name,
           url: (NG_DOCS.html5Mode ? '' : '#/') + section + '/' + name,
           globals: [],
+          components: [],
           controllers: [],
           directives: [],
           services: [],


### PR DESCRIPTION
Borrowing from https://github.com/CodeineLabs/gulp-ngdocs-components to add support for Angular 1.5 components alongside the existing directives.

![grunt-ngdocs-component-example](https://cloud.githubusercontent.com/assets/3385635/24466213/0efe77aa-147e-11e7-9e8c-9c25b2e68495.png)
