### PR TITLE
Use lodash from npm instead of bundled by grunt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "marked": "~0.3.2",
     "shelljs": "~0.3.0",
-    "upath": "~0.2.0"
+    "upath": "~0.2.0",
+    "lodash": "^4.17.4"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -10,7 +10,8 @@ var reader = require('../src/reader.js'),
     ngdoc = require('../src/ngdoc.js'),
     path = require('path'),
     upath = require('upath'),
-    vm = require('vm');
+    vm = require('vm'),
+    _ = require('lodash');
 
 var repohosts = [
   { re: /https?:\/\/github.com\/([^\/]+\/[^\/]+)|git@github.com:(.*)/,
@@ -21,8 +22,7 @@ var repohosts = [
 ];
 
 module.exports = function(grunt) {
-  var _ = grunt.util._,
-      unittest = {},
+  var unittest = {},
       templates = path.resolve(__dirname, '../src/templates');
 
   grunt.registerMultiTask('ngdocs', 'build documentation', function() {

--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -146,7 +146,7 @@ module.exports = function(grunt) {
         values.rev = '' + sha.output;
         values.sha = values.rev.slice(0, 7);
       }
-      tmpl = _.template(tmpl, undefined, {'interpolate': /\{\{(.+?)\}\}/g});
+      tmpl = _.template(tmpl, {'interpolate': /\{\{(.+?)\}\}/g});
       return function(file, line, codeline) {
         values.file = file;
         values.line = line;


### PR DESCRIPTION
Include `lodash` as a dependency from npm. This fixes the `sourceLink` template call for recent lodash versions.

Using the lodash version bundled with grunt is depcreated, see: https://gruntjs.com/api/grunt.util#external-libraries.